### PR TITLE
Preloaded list is added... and a way to render spells as buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,12 @@
       content="width=device-width, initial-scale=1.0"
     />
     <title>Look at things in dnd</title>
+    <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.6"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.js"></script>
     <script src="script.js"></script>
+    <!-- Stylesheets and fonts -->
     <link
       rel="stylesheet"
       href="style.css"

--- a/script.js
+++ b/script.js
@@ -13,36 +13,32 @@ document.addEventListener('DOMContentLoaded', () => {
     tabSelect: true,
   });
 
-  // Fetch the list of monsters once and store it
-  // 🚧 ?source=${encodeURIComponent(selectedSource)}
-  function fetchMonsters(url = 'https://api.open5e.com/v1/monsters/') {
-    axios
-      .get(url)
-      .then((response) => {
-        monsters = response.data.results;
-        console.log('Fetched monsters list:', monsters);
-        // Check if there is a next page
-        if (response.data.next) {
-          fetchMonsters(response.data.next);
-        }
-      })
-      .catch((error) => {
-        console.error('Error fetching monsters:', error);
-        showError('Error fetching monster list.');
-      });
+  // Fetching local JSON file with monster name, slug, ac and source tag.
+  async function loadMonsters() {
+    try {
+      const response = await fetch('public/data/monsters_summary.json');
+      monsters = await response.json();
+      console.log('Monsters loaded:', monsters);
+    } catch (error) {
+      console.error('Error loading monsters:', error);
+      monsterResult.innerHTML = 'Error loading monster list';
+    }
   }
 
-  fetchMonsters();
+  loadMonsters();
 
-  // Add event listener for input to show suggestions from fuzzy search
+  // Fuzzy search for autocomplete
   monsterInput.addEventListener('input', () => {
     const fuse = new Fuse(monsters, {
-      keys: ['name'],
-      threshold: 0.3,
+      keys: ['name'], // Customize fields used for fuzzy search
+      threshold: 0.3, // Adjust threshold for match sensitivity
     });
     const results = fuse
       .search(monsterInput.value)
       .map((result) => result.item.name);
+
+    console.log('Search results:', results); // Check if search results are populated correctly
+    // Ensure Awesomplete list is updated properly
     awesomplete.list = results;
   });
 
@@ -50,67 +46,161 @@ document.addEventListener('DOMContentLoaded', () => {
   searchButton.addEventListener('click', () => {
     const monsterName = monsterInput.value.trim().toLowerCase();
     if (monsterName) {
-      searchMonster(monsterName);
+      const matchedMonster = monsters.find(
+        (monster) => monster.name.toLowerCase() === monsterName
+      );
+
+      if (matchedMonster) {
+        fetchMonsterDetails(matchedMonster.slug); // fetch details using slug
+      } else {
+        monsterResult.innerHTML = 'Monster not found.';
+      }
     } else {
       monsterResult.innerHTML = 'Please enter a monster name.';
     }
   });
 
-  function searchMonster(monsterName) {
-    showLoading(monsterName);
-    const matchedMonster = monsters.find(
-      (monster) => monster.name.toLowerCase() === monsterName
-    );
-    if (matchedMonster) {
-      console.log('Matched monster:', matchedMonster);
-      const monsterUrl = `https://api.open5e.com/v1/monsters/${matchedMonster.slug}/`;
-      axios
-        .get(monsterUrl)
-        .then((monsterResponse) => {
-          renderMonsterDetails(monsterResponse.data);
-        })
-        .catch((error) => {
-          console.error('Error fetching monster details:', error);
-          monsterResult.innerHTML = 'Error fetching monster details.';
-        });
-    } else {
-      console.log(`${monsterName} not found`);
-      showError('Monster not found');
+  // Fetch detailed monster data using slug from Open5e API
+  async function fetchMonsterDetails(slug) {
+    showLoading(slug); // Show loading message
+    try {
+      const monsterUrl = `https://api.open5e.com/v1/monsters/${slug}/`;
+      console.log(monsterUrl);
+      const response = await axios.get(monsterUrl);
+      renderMonsterDetails(response.data);
+    } catch (error) {
+      console.error('Error fetching monster details:', error);
+      monsterResult.innerHTML = 'Error fetching monster details.';
     }
   }
 
+  // Function to handle spell fetching and display name + description
+  async function fetchSpellDetails(spellUrl) {
+    try {
+      // Correcting the spell URL if necessary
+      const correctedSpellUrl = await correctSpellUrl(spellUrl);
+      const response = await axios.get(correctedSpellUrl);
+      const spellData = response.data;
+
+      // Display spell name and description
+      displaySpellDetails(spellData);
+    } catch (error) {
+      console.error('Error fetching spell details:', error);
+    }
+  }
+
+  // Function to correct spell URL by adding the missing 'a5e-ag_' prefix
+  // Might not work for spells that comes from another source.
+  async function correctSpellUrl(spellUrl) {
+    if (!spellUrl.includes('a5e-ag_')) {
+      const spellKey = spellUrl.split('/spells/')[1]; // Extract the spell name
+      console.log(spellKey);
+      console.log(`https://api.open5e.com/v2/spells/a5e-ag_${spellKey}`);
+      return `https://api.open5e.com/v2/spells/a5e-ag_${spellKey}`;
+    }
+    return spellUrl; // Return original spell URL if already correct.
+  }
+
+  // Function to handle spell name and description
+  function displaySpellDetails(spellData) {
+    const spellBlock = `
+    <div class="spell-stat-block">
+      <h3>${spellData.name}</h3>
+      <p><strong>School:</strong> ${spellData.school.name}</p>
+      <p><strong>Description:</strong> ${spellData.desc}</p>
+    </div>
+    `;
+    document.getElementById('spellResult').innerHTML = spellBlock;
+  }
+
+  // Render detailed monster data
   function renderMonsterDetails(monsterData) {
-    // Handle armor class
-    const armorClass = Array.isArray(monsterData.armor_class)
-      ? monsterData.armor_class
-          .map((ac) => `${ac.value} (${ac.type})`)
-          .join(', ')
-      : monsterData.armor_class;
+    const armorClass = `${monsterData.armor_class} (${monsterData.armor_desc || 'natural armor'})`;
+    const imageUrl = monsterData.img_main ? monsterData.img_main : '';
+    const actions = monsterData.actions || [];
+    const legendaryActions = monsterData.legendary_actions || [];
+    const spellList = monsterData.spell_list || [];
 
-    console.log(armorClass);
+    const statBlockHtml = `
+      <div class="monster-stat-block">
+        <h2 class="monster-name">${monsterData.name}</h2>
+        ${imageUrl ? `<img src="${imageUrl}" alt="${monsterData.name}" class="monster-image">` : ''}
 
-    // Handle image
-    const imageUrl = monsterData.image
-      ? `https://api.open5e.com${monsterData.image}`
-      : '';
+        <p><strong>Type:</strong> ${monsterData.size} ${monsterData.type}, ${monsterData.alignment}</p>
+        <p><strong>Armor Class:</strong> ${armorClass}</p>
+        <p><strong>Hit Points:</strong> ${monsterData.hit_points} (${monsterData.hit_dice})</p>
+        <p><strong>Speed:</strong> ${monsterData.speed.walk || '0'} ft${monsterData.speed.fly ? `, fly ${monsterData.speed.fly} ft` : ''}${monsterData.speed.swim ? `, swim ${monsterData.speed.swim} ft` : ''}</p>
+        <p><strong>Challenge Rating:</strong> ${monsterData.challenge_rating}</p>
 
-    monsterResult.innerHTML = `
-            <h2>${monsterData.name}</h2>
-            <p><strong>Size:</strong> ${monsterData.size}</p>
-            <p><strong>Armor Class:</strong> ${armorClass}</p>
-            <p><strong>HP:</strong> ${monsterData.hit_points}</p>
-            <p><strong>Speed:</strong> ${monsterData.speed.walk} ft</p>
-            ${imageUrl ? `<img src="${imageUrl}" alt="${monsterData.name}" class="monster-image">` : ''}
-          `;
+        <div class="monster-abilities">
+          <h3>Abilities</h3>
+          <p><strong>STR:</strong> ${monsterData.strength}, <strong>DEX:</strong> ${monsterData.dexterity}, <strong>CON:</strong> ${monsterData.constitution}</p>
+          <p><strong>INT:</strong> ${monsterData.intelligence}, <strong>WIS:</strong> ${monsterData.wisdom}, <strong>CHA:</strong> ${monsterData.charisma}</p>
+        </div>
+
+        <div class="monster-skills">
+          ${
+            monsterData.skills
+              ? `<p><strong>Skills:</strong> ${Object.entries(
+                  monsterData.skills
+                )
+                  .map(([skill, value]) => `${skill} +${value}`)
+                  .join(', ')}</p>`
+              : ''
+          }
+          ${monsterData.senses ? `<p><strong>Senses:</strong> ${monsterData.senses}</p>` : ''}
+          ${monsterData.languages ? `<p><strong>Languages:</strong> ${monsterData.languages}</p>` : ''}
+        </div>
+
+        <div class="monster-actions">
+          <h3>Actions</h3>
+          <ul>
+            ${actions.map((action) => `<li><strong>${action.name}:</strong> ${action.desc}</li>`).join('')}
+          </ul>
+        </div>
+
+        ${
+          legendaryActions.length > 0
+            ? `
+        <div class="monster-legendary-actions">
+          <h3>Legendary Actions</h3>
+          <ul>
+            ${legendaryActions.map((action) => `<li><strong>${action.name}:</strong> ${action.desc}</li>`).join('')}
+          </ul>
+        </div>`
+            : ''
+        }
+
+        ${
+          spellList.length > 0
+            ? `
+        <div class="spell-list">
+          <h3>Spells</h3>
+          ${spellList
+            .map(
+              (spellUrl) =>
+                `<button class="spell-btn" data-spell-url="${spellUrl}">${spellUrl.split('/spells/')[1].replaceAll('-', ' ').replace('/', '')}</button>`
+            )
+            .join('')}
+        </div>
+        <div id="spellResult"></div>`
+            : ''
+        }
+      </div>
+    `;
+
+    monsterResult.innerHTML = statBlockHtml;
+
+    // Attach event listeners for the spell buttons after they are rendered
+    const spellButtons = document.querySelectorAll('.spell-btn');
+    spellButtons.forEach((button) => {
+      const spellUrl = button.getAttribute('data-spell-url');
+      button.addEventListener('click', () => fetchSpellDetails(spellUrl));
+    });
   }
 
   // loading text for user
   function showLoading(monsterName) {
     monsterResult.innerHTML = `<p>Chasing down ${monsterName}...</p>`;
-  }
-
-  // Handling missing monster
-  function showError(message) {
-    monsterResult.innerHTML = `<p class='error'>${message}</p>`;
   }
 });

--- a/style.css
+++ b/style.css
@@ -196,3 +196,75 @@ h1 {
 .awesomplete .visually-hidden {
   display: none;
 }
+
+.monster-stat-block {
+  border: 1px solid #444;
+  padding: 16px;
+  background-color: #f9f9f9;
+  max-width: 600px;
+  margin: 20px auto;
+}
+
+.monster-name {
+  text-align: center;
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.monster-image {
+  display: block;
+  margin: 10px auto;
+  max-width: 100%;
+}
+
+.monster-abilities,
+.monster-actions,
+.monster-legendary-actions,
+.monster-spells {
+  margin-top: 20px;
+}
+
+h3 {
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 5px;
+  font-size: 18px;
+}
+
+ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+ul li {
+  margin-bottom: 10px;
+}
+
+.monster-spells p {
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+p {
+  font-size: 16px;
+  margin: 5px 0;
+}
+
+.spell-stat-block {
+  border: 1px solid #444;
+  padding: 10px;
+  background-color: #f9f9f9;
+  margin-top: 10px;
+}
+
+.spell-stat-block h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.spell-list button {
+  margin: 5px;
+  padding: 8px 12px;
+  font-size: 14px;
+  cursor: pointer;
+}


### PR DESCRIPTION
To render spells with the broken link in the monster description. A missing part of the url in spells on the Archmage. Possibly from the transition to spell api v2.